### PR TITLE
Removed abandoned container-interop/container-interop.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,7 @@
         "symfony/event-dispatcher": "~2.1||~3.0||~4.0||~5.0",
         "symfony/translation": "~2.3||~3.0||~4.0||~5.0",
         "symfony/yaml": "~2.1||~3.0||~4.0||~5.0",
-        "psr/container": "^1.0",
-        "container-interop/container-interop": "^1.2"
+        "psr/container": "^1.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
Please merge this.

I'm tired of seeing the abandoned package message.